### PR TITLE
feat: interactive onboarding overlays for Assistants and Knowledge Base

### DIFF
--- a/src/app/(app)/assistants/page.tsx
+++ b/src/app/(app)/assistants/page.tsx
@@ -20,6 +20,7 @@ import { Input } from '@/components/ui/input';
 import { ContactsProvider } from '../contacts/contexts/contacts-context';
 
 import { AssistantCard } from './components/assistant-card';
+import { AssistantsOnboarding } from '@/components/onboarding/assistants-onboarding';
 
 const AssistantStudio = dynamic(
   () => import('./components/assistant-studio'),
@@ -43,10 +44,16 @@ function AssistantsGallery() {
   const searchParams = useSearchParams();
   const [search, setSearch] = useState('');
   const [showBrief, setShowBrief] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   useEffect(() => {
     const isDismissed = localStorage.getItem('monade_studio_brief_dismissed');
     if (!isDismissed) setShowBrief(true);
+  }, []);
+
+  useEffect(() => {
+    const done = localStorage.getItem('monade_assistants_onboarding_v1');
+    if (!done) setShowOnboarding(true);
   }, []);
 
   const dismissBrief = () => {
@@ -118,7 +125,7 @@ function AssistantsGallery() {
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/60" />
               <Input placeholder="Find an assistant..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-10 w-64 bg-muted/10 border-border/40 text-xs focus:ring-primary focus:border-primary transition-all rounded-md" />
             </div>
-            <Button onClick={handleCreateDraft} className="h-10 px-4 gap-2 bg-foreground text-background hover:bg-foreground/90 transition-all rounded-[4px] text-[10px] font-bold uppercase tracking-[0.2em]"><Plus size={16} />Add Assistant</Button>
+            <Button data-onboarding="add-assistant" onClick={handleCreateDraft} className="h-10 px-4 gap-2 bg-foreground text-background hover:bg-foreground/90 transition-all rounded-[4px] text-[10px] font-bold uppercase tracking-[0.2em]"><Plus size={16} />Add Assistant</Button>
           </div>
         </div>
 
@@ -220,8 +227,15 @@ function AssistantsGallery() {
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
             <AnimatePresence>
-              {filteredAssistants.map((assistant) => (
-                <motion.div key={assistant.id} layout initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}>
+              {filteredAssistants.map((assistant, idx) => (
+                <motion.div
+                  key={assistant.id}
+                  layout
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  {...(idx === 0 ? { 'data-onboarding': 'first-assistant' } : {})}
+                >
                   <AssistantCard assistant={assistant} onSelect={setCurrentAssistant} />
                 </motion.div>
               ))}
@@ -232,6 +246,18 @@ function AssistantsGallery() {
 
       <AnimatePresence>
         {currentAssistant && <AssistantStudioWorkspace />}
+      </AnimatePresence>
+
+      <AnimatePresence>
+        {showOnboarding && (
+          <AssistantsOnboarding
+            isOpen={showOnboarding}
+            onComplete={() => {
+              setShowOnboarding(false);
+              localStorage.setItem('monade_assistants_onboarding_v1', 'true');
+            }}
+          />
+        )}
       </AnimatePresence>
     </div>
   );

--- a/src/app/(app)/knowledge-base/page.tsx
+++ b/src/app/(app)/knowledge-base/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useMemo, useCallback } from 'react';
+import { AnimatePresence } from 'framer-motion';
 import { 
   Search, 
   Plus, 
@@ -26,6 +27,7 @@ import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
 
 import { LibraryWorkshop } from './components/library-workshop';
+import { LibraryOnboarding } from '@/components/onboarding/library-onboarding';
 
 // --- Helpers ---
 
@@ -200,7 +202,13 @@ export default function LibraryPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [isWorkshopOpen, setIsWorkshopOpen] = useState(false);
   const [editingItem, setEditingItem] = useState<LibraryItem | null>(null);
-  
+  const [showOnboarding, setShowOnboarding] = useState(false);
+
+  useEffect(() => {
+    const done = localStorage.getItem('monade_library_onboarding_v1');
+    if (!done) setShowOnboarding(true);
+  }, []);
+
   const itemsPerPage = 8;
 
   const assistantLinksByKnowledgeKey = useMemo(() => {
@@ -292,7 +300,7 @@ export default function LibraryPage() {
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground/60" />
               <Input placeholder="Search your files..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9 h-10 w-64 bg-muted/10 border-border/40 text-xs focus:ring-primary focus:border-primary transition-all rounded-md" />
             </div>
-            <Button onClick={() => setIsWorkshopOpen(true)} className="h-10 px-4 gap-2 bg-foreground text-background hover:bg-foreground/90 transition-all rounded-[4px] text-[10px] font-bold uppercase tracking-[0.2em]"><Plus size={16} />Add Info</Button>
+            <Button data-onboarding="add-info" onClick={() => setIsWorkshopOpen(true)} className="h-10 px-4 gap-2 bg-foreground text-background hover:bg-foreground/90 transition-all rounded-[4px] text-[10px] font-bold uppercase tracking-[0.2em]"><Plus size={16} />Add Info</Button>
           </div>
         </div>
 
@@ -362,6 +370,18 @@ export default function LibraryPage() {
         )}
       </main>
       <LibraryWorkshop isOpen={isWorkshopOpen} onClose={handleCloseWorkshop} editItem={editingItem} />
+
+      <AnimatePresence>
+        {showOnboarding && (
+          <LibraryOnboarding
+            isOpen={showOnboarding}
+            onComplete={() => {
+              setShowOnboarding(false);
+              localStorage.setItem('monade_library_onboarding_v1', 'true');
+            }}
+          />
+        )}
+      </AnimatePresence>
     </div>
   );
 }

--- a/src/components/onboarding/assistants-onboarding.tsx
+++ b/src/components/onboarding/assistants-onboarding.tsx
@@ -1,0 +1,499 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence, useMotionValue, animate } from 'framer-motion';
+import { ArrowUpRight, Cpu, Volume2, X } from 'lucide-react';
+
+// ─── Step definitions ─────────────────────────────────────────────────────────
+// All 4 steps advance via Next. No early exits. Step 4 closes dialog.
+
+const STEPS = [
+  {
+    num: '01',
+    title: 'Your AI Voice Agents',
+    desc: 'Each assistant is an autonomous voice AI. It makes calls, handles objections, classifies intent, and summarizes every conversation — without a human in the loop.',
+    bullets: ['Human-quality voice', 'Real-time lead classification', 'Auto-generated call summaries'],
+    cta: 'Next →',
+  },
+  {
+    num: '02',
+    title: 'Create in Seconds',
+    desc: 'Tap + Add Assistant to build your first AI agent. Name it, pick a voice, define its personality. No ML background needed.',
+    bullets: ['No-code configuration', 'Multiple voice options', 'Custom scripts & greetings'],
+    cta: 'Next →',
+  },
+  {
+    num: '03',
+    title: 'The Studio',
+    desc: 'Every assistant has a Studio — a workspace where you configure its voice, script, and knowledge. Click any card to open it.',
+    bullets: ['Script editor with variables', 'Knowledge base integration', 'Live call testing'],
+    cta: 'Next →',
+  },
+  {
+    num: '04',
+    title: 'Go Live',
+    desc: "Test with a real call, then scale to thousands via Campaigns. Your agent handles everything — you watch the leads roll in.",
+    bullets: ['Single call test mode', 'Campaign-level scaling', 'Real-time monitoring'],
+    cta: "Let's go →",
+  },
+] as const;
+
+// ─── Cursor positions (absolute y from left panel top = 0) ────────────────────
+//
+// Panel structure:
+//   Browser bar (rendered outside MockUI):  y = 0–36px     (36px tall)
+//   MockUI header bar (bg-zinc-900):         y = 36–72px    (36px tall)
+//   Tabs row:                                y = 72–96px    (24px tall)
+//   Grid container (p-3 = 12px padding):     cards start y = 96+12 = 108px
+//   Card0 (200px tall):                      y = 108–308px  center = 208
+//   Card0 arrow button (20px from bottom):   y ≈ 290,  x ≈ 200
+//   "+ Add" button (header right side):      x ≈ 388,  y = 36+18 = 54
+
+const CURSOR_POS = [
+  { x: 116, y: 208 }, // step 1 — hover card 0 center
+  { x: 388, y: 54  }, // step 2 — "+ Add" button in header
+  { x: 116, y: 208 }, // step 3 — click card 0 (opens studio)
+  { x: 200, y: 290 }, // step 4 — arrow button bottom-right of card 0
+] as const;
+
+// ─── Mock assistant card — mirrors real AssistantCard structure ───────────────
+//   Real card: h-[360px], avatar (LeadIcon 52px) + name, READY badge,
+//   "Primary Role" label + italic desc, Model/Voice 2-col grid,
+//   "Operating History" + "1,240m Talked" + circle arrow button
+
+function MockAssistantCard({
+  name,
+  role,
+  model,
+  voice,
+  history,
+  gradient,
+  highlighted,
+  arrowActive,
+}: {
+  name: string;
+  role: string;
+  model: string;
+  voice: string;
+  history: string;
+  gradient: string;
+  highlighted: boolean;
+  arrowActive: boolean;
+}) {
+  return (
+    <div
+      className={`rounded-md border flex flex-col overflow-hidden transition-all duration-300 ${
+        highlighted
+          ? 'border-yellow-400/60 shadow-[0_0_14px_rgba(250,204,21,0.12)]'
+          : 'border-zinc-700/40'
+      } bg-zinc-800/60`}
+      style={{ height: 200 }}
+    >
+      {/* Header: avatar + name + READY badge */}
+      <div className="px-3 pt-3 flex items-center justify-between shrink-0">
+        <div className="flex items-center gap-2">
+          <div className={`w-6 h-6 rounded-full bg-gradient-to-br ${gradient} shrink-0`} />
+          <span className="text-[10px] font-semibold text-zinc-200 tracking-tight truncate max-w-[72px]">{name}</span>
+        </div>
+        <div className="flex items-center gap-1 px-1.5 py-0.5 bg-green-500 rounded-full shrink-0">
+          <div className="w-1 h-1 rounded-full bg-white" />
+          <span className="text-[6px] font-bold text-white uppercase tracking-wider">READY</span>
+        </div>
+      </div>
+
+      {/* Primary Role */}
+      <div className="px-3 pt-2 flex-1 min-h-0">
+        <div className="text-[6px] font-bold uppercase tracking-widest text-zinc-500 mb-0.5">Primary Role</div>
+        <p className="text-[7.5px] italic text-zinc-400 leading-relaxed line-clamp-3">"{role}"</p>
+      </div>
+
+      {/* Model / Voice metadata — mirrors the 2-col grid in real card */}
+      <div className="mx-3 border-t border-zinc-700/40 pt-1.5 pb-1.5 grid grid-cols-2 gap-x-3 shrink-0">
+        <div>
+          <div className="flex items-center gap-0.5 mb-0.5">
+            <Cpu size={6} className="text-yellow-400/50" />
+            <span className="text-[6px] uppercase tracking-widest text-zinc-600">Model</span>
+          </div>
+          <span className="text-[8px] font-semibold text-zinc-300">{model}</span>
+        </div>
+        <div>
+          <div className="flex items-center gap-0.5 mb-0.5">
+            <Volume2 size={6} className="text-yellow-400/50" />
+            <span className="text-[6px] uppercase tracking-widest text-zinc-600">Voice</span>
+          </div>
+          <span className="text-[8px] font-semibold text-zinc-300">{voice}</span>
+        </div>
+      </div>
+
+      {/* Footer: history + circle arrow button — mirrors real card bottom row */}
+      <div className="mx-3 border-t border-zinc-700/40 pt-1.5 pb-2.5 flex items-center justify-between shrink-0">
+        <div>
+          <div className="text-[6px] uppercase tracking-widest text-zinc-600">Operating History</div>
+          <div className="text-[8.5px] font-mono font-bold text-zinc-300">{history}</div>
+        </div>
+        <div
+          className={`w-7 h-7 rounded-full flex items-center justify-center transition-all duration-300 border ${
+            arrowActive
+              ? 'bg-yellow-400 text-zinc-900 shadow-[0_0_12px_rgba(250,204,21,0.45)] scale-110 border-yellow-300'
+              : 'bg-zinc-700 text-zinc-300 border-zinc-600/40'
+          }`}
+        >
+          <ArrowUpRight size={11} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Assistants page mock UI ──────────────────────────────────────────────────
+// Faithfully renders: page header bar, All/Production/Drafts tabs, card grid.
+// Step-specific state:
+//   step 0: card 0 highlighted (hover effect)
+//   step 1: + Add button glows, draft card animates in at position [2]
+//   step 2: card 0 highlighted, studio panel slides in from right
+//   step 3: arrow button on card 0 turns primary color
+
+function AssistantsMockUI({ step }: { step: number }) {
+  const showDraftCard = step >= 1;
+  const showStudio    = step >= 2;
+
+  return (
+    <div className="flex flex-col h-full select-none overflow-hidden">
+
+      {/* ── Page header (mirrors: "Assistants" title area + search + Add button) ── */}
+      <div
+        className="shrink-0 bg-zinc-900/80 border-b border-zinc-800 px-3 flex items-center justify-between"
+        style={{ height: 36 }}
+      >
+        <span className="text-[9px] font-bold text-white tracking-widest uppercase">Assistants</span>
+        <div className="flex items-center gap-1.5">
+          {/* Search input shape */}
+          <div className="h-5 w-[72px] rounded bg-zinc-700/60 flex items-center px-2 gap-1.5">
+            <div className="w-1.5 h-1.5 rounded-full bg-zinc-500 shrink-0" />
+            <div className="h-1 flex-1 bg-zinc-600/70 rounded-full" />
+          </div>
+          {/* + Add button — glows on step 1 */}
+          <div
+            className={`h-5 px-2 rounded-[3px] flex items-center gap-1 transition-all duration-300 ${
+              step === 1
+                ? 'bg-white shadow-[0_0_12px_5px_rgba(255,255,255,0.22)]'
+                : 'bg-zinc-200/90'
+            }`}
+          >
+            <span className="text-[7.5px] font-bold text-zinc-900">+ Add</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Tabs row (mirrors: All Assistants | Production | Drafts) ── */}
+      <div
+        className="shrink-0 px-3 flex items-center gap-4 bg-zinc-900/40 border-b border-zinc-800/50"
+        style={{ height: 24 }}
+      >
+        <span className="text-[7px] font-bold text-white border-b border-white pb-px leading-none">ALL</span>
+        <span className="text-[7px] font-bold text-zinc-500 leading-none">PRODUCTION</span>
+        <span className="text-[7px] font-bold text-zinc-500 leading-none">DRAFTS</span>
+      </div>
+
+      {/* ── Grid + optional studio panel ── */}
+      <div className="flex flex-1 overflow-hidden">
+
+        {/* Card grid */}
+        <div className="flex-1 p-3 overflow-hidden">
+          <div className="grid grid-cols-2 gap-2 content-start">
+
+            {/* Card 0 — Nova Sales */}
+            <MockAssistantCard
+              name="Nova Sales"
+              role="Intelligent outbound lead qualification and objection handling."
+              model="GPT-4o"
+              voice="Alloy"
+              history="1,240m Talked"
+              gradient="from-purple-500/70 to-blue-500/70"
+              highlighted={step === 0 || step === 2}
+              arrowActive={step === 3}
+            />
+
+            {/* Card 1 — Echo Support */}
+            <MockAssistantCard
+              name="Echo Support"
+              role="Customer support triage and inbound escalation routing."
+              model="GPT-4o"
+              voice="Echo"
+              history="892m Talked"
+              gradient="from-orange-500/70 to-red-500/70"
+              highlighted={false}
+              arrowActive={false}
+            />
+
+            {/* Draft card — animates in on step 1 */}
+            <AnimatePresence>
+              {showDraftCard && (
+                <motion.div
+                  key="draft"
+                  initial={{ scale: 0.82, opacity: 0 }}
+                  animate={{ scale: 1, opacity: 1 }}
+                  exit={{ scale: 0.82, opacity: 0 }}
+                  transition={{ duration: 0.38, ease: 'easeOut', delay: 0.85 }}
+                  className="rounded-md border border-dashed border-zinc-600/50 bg-zinc-800/30 flex flex-col p-3"
+                  style={{ height: 200 }}
+                >
+                  <div className="flex items-center gap-2">
+                    <div className="w-6 h-6 rounded-full bg-zinc-700 shrink-0" />
+                    <span className="text-[10px] font-semibold text-zinc-400">New Assistant</span>
+                  </div>
+                  <div className="mt-1.5 w-fit flex items-center gap-1 px-1.5 py-0.5 bg-zinc-700/60 rounded-full border border-zinc-600/40">
+                    <span className="text-[6px] font-bold text-zinc-400 uppercase tracking-wider">DRAFT</span>
+                  </div>
+                  <div className="mt-3 space-y-1.5">
+                    <div className="h-1.5 w-3/4 bg-zinc-700/50 rounded-full" />
+                    <div className="h-1.5 w-1/2 bg-zinc-700/30 rounded-full" />
+                    <div className="h-1.5 w-2/3 bg-zinc-700/20 rounded-full" />
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+
+        {/* Studio panel — slides in on step 2 (mirrors the real AssistantStudio right-panel feel) */}
+        <AnimatePresence>
+          {showStudio && (
+            <motion.div
+              key="studio"
+              initial={{ x: '100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '100%' }}
+              transition={{ duration: 0.38, ease: 'easeInOut', delay: 0.65 }}
+              className="shrink-0 bg-zinc-900 border-l border-zinc-700/60 flex flex-col overflow-hidden"
+              style={{ width: '46%' }}
+            >
+              {/* Studio header */}
+              <div className="px-2.5 py-1.5 border-b border-zinc-800 shrink-0">
+                <div className="text-[7px] font-bold text-white uppercase tracking-widest">Nova Sales</div>
+                <div className="text-[6px] text-zinc-500 uppercase tracking-widest">Studio</div>
+              </div>
+              {/* Script / Knowledge / Voice tabs */}
+              <div className="px-2.5 py-1 flex gap-2.5 border-b border-zinc-800/60 shrink-0">
+                {['Script', 'Knowledge', 'Voice'].map((t, i) => (
+                  <span
+                    key={t}
+                    className={`text-[6.5px] font-bold uppercase tracking-widest ${
+                      i === 0
+                        ? 'text-yellow-400 border-b border-yellow-400 pb-px'
+                        : 'text-zinc-500'
+                    }`}
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+              {/* Script editor — rows of text lines simulating a script */}
+              <div className="flex-1 p-2.5 space-y-1.5 overflow-hidden">
+                {[92, 78, 88, 55, 70, 84, 42, 65, 88, 50, 72].map((w, i) => (
+                  <div key={i} className="h-1.5 bg-zinc-700/50 rounded-full" style={{ width: `${w}%` }} />
+                ))}
+                {/* Blinking cursor line */}
+                <div className="flex items-center gap-0.5">
+                  <div className="h-1.5 w-1/3 bg-zinc-700/50 rounded-full" />
+                  <div className="h-3 w-0.5 bg-yellow-400 animate-pulse" />
+                </div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface AssistantsOnboardingProps {
+  isOpen: boolean;
+  onComplete: () => void;
+}
+
+export function AssistantsOnboarding({ isOpen, onComplete }: AssistantsOnboardingProps) {
+  const [step, setStep] = useState(0);
+  const [showRipple, setShowRipple] = useState(false);
+
+  const cursorX = useMotionValue(CURSOR_POS[0].x);
+  const cursorY = useMotionValue(CURSOR_POS[0].y);
+
+  // Animate cursor to new position on step change
+  useEffect(() => {
+    if (!isOpen) return;
+    const pos = CURSOR_POS[step];
+    animate(cursorX, pos.x, { duration: 0.75, ease: 'easeInOut' });
+    animate(cursorY, pos.y, { duration: 0.75, ease: 'easeInOut' });
+
+    // Show click ripple when cursor arrives at a clickable (steps 1 and 2)
+    if (step === 1 || step === 2) {
+      const t = setTimeout(() => {
+        setShowRipple(true);
+        setTimeout(() => setShowRipple(false), 600);
+      }, 820);
+      return () => clearTimeout(t);
+    }
+  }, [step, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) setStep(0);
+  }, [isOpen]);
+
+  const handleCta = () => {
+    if (step < STEPS.length - 1) {
+      setStep(s => s + 1);
+    } else {
+      onComplete();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        transition={{ duration: 0.25, ease: 'easeOut' }}
+        className="w-full max-w-4xl h-[560px] flex rounded-xl overflow-hidden shadow-2xl border border-white/[0.08]"
+      >
+
+        {/* ── LEFT PANEL: always dark, browser chrome + mock page ─────────── */}
+        <div
+          className="relative w-1/2 bg-zinc-950 flex flex-col overflow-hidden"
+          style={{ colorScheme: 'dark' }}
+        >
+          {/* Browser chrome bar */}
+          <div
+            className="shrink-0 flex items-center gap-1.5 px-3 bg-zinc-900/90 border-b border-zinc-800"
+            style={{ height: 36 }}
+          >
+            <div className="w-2.5 h-2.5 rounded-full bg-red-500/70" />
+            <div className="w-2.5 h-2.5 rounded-full bg-yellow-500/70" />
+            <div className="w-2.5 h-2.5 rounded-full bg-green-500/70" />
+            <div className="ml-2 flex-1 h-4 rounded bg-zinc-800/80 flex items-center px-2">
+              <span className="text-[7.5px] text-zinc-500">app.monade.ai/assistants</span>
+            </div>
+          </div>
+
+          {/* Mock page — does NOT re-mount on step change so animations persist */}
+          <div className="flex-1 overflow-hidden">
+            <AssistantsMockUI step={step} />
+          </div>
+
+          {/* Animated cursor — positioned absolutely within panel (y=0 = panel top) */}
+          <motion.div
+            className="absolute top-0 left-0 pointer-events-none z-20"
+            style={{ x: cursorX, y: cursorY }}
+          >
+            <svg width="16" height="20" viewBox="0 0 16 20" fill="none">
+              <path
+                d="M1 1L1 15.5L4 12L6.5 17.5L8.5 16.5L6 11H10L1 1Z"
+                fill="white"
+                stroke="#111"
+                strokeWidth="1.2"
+                strokeLinejoin="round"
+              />
+            </svg>
+            {/* Click ripple */}
+            <AnimatePresence>
+              {showRipple && (
+                <motion.div
+                  key="ripple"
+                  className="absolute top-0 left-0 rounded-full bg-white/25"
+                  style={{ width: 22, height: 22, x: -3, y: -3 }}
+                  initial={{ scale: 0.4, opacity: 0.8 }}
+                  animate={{ scale: 2.2, opacity: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.48, ease: 'easeOut' }}
+                />
+              )}
+            </AnimatePresence>
+          </motion.div>
+        </div>
+
+        {/* ── RIGHT PANEL: respects system theme ──────────────────────────── */}
+        <div className="relative w-1/2 bg-background flex flex-col p-8 border-l border-border/20">
+
+          {/* Skip */}
+          <button
+            onClick={onComplete}
+            className="absolute top-5 right-5 p-1.5 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Skip onboarding"
+          >
+            <X size={16} />
+          </button>
+
+          {/* Step counter */}
+          <span className="text-[10px] font-bold text-primary uppercase tracking-[0.3em] mb-6">
+            {STEPS[step].num} / 04
+          </span>
+
+          {/* Step content with slide transition */}
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={step}
+              initial={{ opacity: 0, x: 18 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -18 }}
+              transition={{ duration: 0.22, ease: 'easeInOut' }}
+              className="flex-1 flex flex-col gap-5"
+            >
+              <h2 className="text-2xl font-medium tracking-tight text-foreground leading-tight">
+                {STEPS[step].title}
+              </h2>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {STEPS[step].desc}
+              </p>
+              <ul className="space-y-2 mt-1">
+                {STEPS[step].bullets.map((b, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm text-foreground/80">
+                    <span className="text-primary mt-0.5 shrink-0">•</span>
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+            </motion.div>
+          </AnimatePresence>
+
+          {/* Bottom navigation row */}
+          <div className="flex items-center justify-between mt-auto pt-6 border-t border-border/20">
+            <button
+              onClick={() => setStep(s => Math.max(0, s - 1))}
+              className={`text-xs font-medium transition-all ${
+                step === 0
+                  ? 'opacity-0 pointer-events-none'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              ← Back
+            </button>
+
+            {/* Step dots */}
+            <div className="flex items-center gap-1.5">
+              {STEPS.map((_, i) => (
+                <div
+                  key={i}
+                  className={`rounded-full transition-all duration-300 ${
+                    i === step ? 'w-4 h-1.5 bg-primary' : 'w-1.5 h-1.5 bg-border'
+                  }`}
+                />
+              ))}
+            </div>
+
+            <button
+              onClick={handleCta}
+              className="px-4 py-2 bg-foreground text-background text-xs font-bold uppercase tracking-[0.15em] rounded-[4px] hover:bg-foreground/90 transition-all"
+            >
+              {STEPS[step].cta}
+            </button>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/onboarding/library-onboarding.tsx
+++ b/src/components/onboarding/library-onboarding.tsx
@@ -1,0 +1,506 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { motion, AnimatePresence, useMotionValue, animate } from 'framer-motion';
+import { ArrowUpRight, Bot, ChevronRight, Cpu, FileText, Globe, X } from 'lucide-react';
+
+// ─── Step definitions ─────────────────────────────────────────────────────────
+// All 4 steps advance via Next. No early exits.
+
+const STEPS = [
+  {
+    num: '01',
+    title: "Your AI's Memory",
+    desc: "The Knowledge base is the brain behind your assistants. Every fact, script, and pricing detail you upload becomes accessible during live calls — no hallucinations on your data.",
+    bullets: ['Structured factual context', 'Accessible during every call', 'Eliminates AI hallucinations'],
+    cta: 'Next →',
+  },
+  {
+    num: '02',
+    title: 'Add Facts Instantly',
+    desc: 'Tap + Add Info to upload a document or paste text directly. Your assistants absorb it immediately — no retraining, no waiting.',
+    bullets: ['Upload TXT, PDF, or Markdown', 'Direct text entry', 'Versioned updates'],
+    cta: 'Next →',
+  },
+  {
+    num: '03',
+    title: 'Link to Assistants',
+    desc: 'Connect a knowledge file to one or more assistants. Hover any card to instantly see which agents are using it — and manage those links.',
+    bullets: ['Multi-assistant sharing', 'Hover cards show active links', 'Zero downtime updates'],
+    cta: 'Next →',
+  },
+  {
+    num: '04',
+    title: 'Archive & Refine',
+    desc: 'Every document lives in the Archive. Filter by date, search by name, and click any file to open the editor and push a refined version.',
+    bullets: ['Date range filtering', 'Full-text search', 'Versioned refinement'],
+    cta: "Let's go →",
+  },
+] as const;
+
+// ─── Cursor positions (absolute y from left panel top = 0) ────────────────────
+//
+// Panel structure:
+//   Browser bar:                              y = 0–36px     (36px)
+//   MockUI page header:                       y = 36–72px    (36px) → center y=54
+//   "Currently in Use" section label:         y = 72–100px   (28px)
+//   Cards grid (p-3 = 12px padding):
+//     cards start at panel y = 100+12 = 112px
+//     Card0 (130px tall):                     y = 112–242px  center = 177
+//   8px gap + "All Documents" section label:  y = 250–278px  (28px)
+//   Filter pills row:                         y = 278–298px  (20px)
+//   Archive container starts at:              y = 298px
+//     Row 0 (36px tall, matching real p-4):   y = 298–334px  center = 316
+
+const CURSOR_POS = [
+  { x: 116, y: 177 }, // step 1 — center of knowledge card 0 (hover)
+  { x: 388, y: 54  }, // step 2 — "+ Add Info" button in header
+  { x: 116, y: 177 }, // step 3 — card 0 again (trigger hover overlay)
+  { x: 150, y: 316 }, // step 4 — first archive row center
+] as const;
+
+// ─── Mock knowledge card — mirrors real LinkedMemoryCard structure ─────────────
+//   Real card: h-[320px], p-6 header, px-8 content
+//   Top: "Added DATE" (text-primary) + "X Links" badge
+//   Body: filename (text-2xl) + monospace snippet (h-[100px])
+//   Footer: Volume (~N words, Cpu icon) + Market (English, Globe icon) + arrow
+
+function MockKnowledgeCard({
+  date,
+  filename,
+  snippet,
+  wordCount,
+  linkCount,
+  highlighted,
+  showOverlay,
+}: {
+  date: string;
+  filename: string;
+  snippet: string;
+  wordCount: string;
+  linkCount: number;
+  highlighted: boolean;
+  showOverlay: boolean;
+}) {
+  return (
+    <div
+      className={`relative rounded-md border overflow-hidden flex flex-col transition-all duration-300 ${
+        highlighted
+          ? 'border-yellow-400/50 shadow-[0_0_12px_rgba(250,204,21,0.12)]'
+          : 'border-zinc-700/40'
+      } bg-zinc-800/60`}
+      style={{ height: 130 }}
+    >
+      {/* Header: date label (primary color) + links badge */}
+      <div className="px-2.5 pt-2 flex items-center justify-between shrink-0">
+        <span className="text-[6.5px] font-bold uppercase tracking-[0.18em] text-yellow-400/90">
+          Added {date}
+        </span>
+        <div className="px-1.5 py-0.5 rounded-full border border-zinc-600/50 bg-zinc-700/30">
+          <span className="text-[6px] font-bold uppercase tracking-widest text-zinc-400">
+            {linkCount} Links
+          </span>
+        </div>
+      </div>
+
+      {/* Filename — mirrors real card's text-2xl font-medium */}
+      <div className="px-2.5 pt-1 shrink-0">
+        <span className="text-[9.5px] font-semibold text-zinc-200 tracking-tight truncate block">{filename}</span>
+      </div>
+
+      {/* Snippet — mirrors real font-mono text overflow */}
+      <div className="px-2.5 pt-1 flex-1 overflow-hidden relative">
+        <p className="text-[7px] font-mono text-zinc-500 leading-relaxed">{snippet}</p>
+        <div className="absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-t from-zinc-800/80 to-transparent" />
+      </div>
+
+      {/* Footer: Volume + Market + arrow — mirrors real card bottom row */}
+      <div className="mx-2.5 border-t border-zinc-700/40 pt-1 pb-2 flex items-center justify-between shrink-0">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-1">
+            <Cpu size={7} className="text-yellow-400/50" />
+            <span className="text-[6.5px] font-mono font-bold text-zinc-400">~{wordCount}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Globe size={7} className="text-blue-400/50" />
+            <span className="text-[6.5px] font-bold text-zinc-400">English</span>
+          </div>
+        </div>
+        <div className="w-5 h-5 rounded-full bg-zinc-700 text-zinc-300 flex items-center justify-center">
+          <ArrowUpRight size={9} />
+        </div>
+      </div>
+
+      {/* Hover overlay — mirrors real card's translate-y reveal showing connected assistants */}
+      <AnimatePresence>
+        {showOverlay && (
+          <motion.div
+            initial={{ y: '100%' }}
+            animate={{ y: 0 }}
+            exit={{ y: '100%' }}
+            transition={{ duration: 0.32, ease: 'easeInOut' }}
+            className="absolute inset-0 bg-zinc-900/96 backdrop-blur-sm flex flex-col p-2.5 z-10"
+          >
+            <div className="text-[6.5px] font-bold uppercase tracking-[0.2em] text-yellow-400 mb-1">
+              Connected Assistants
+            </div>
+            <div className="text-[8px] font-medium text-zinc-200 mb-1.5">Active Operational Links</div>
+            <div className="space-y-1 flex-1 overflow-hidden">
+              {['Nova Sales', 'Echo Support'].map(name => (
+                <div key={name} className="flex items-center justify-between px-1.5 py-1 rounded border border-zinc-700/50 bg-zinc-800/50">
+                  <div className="flex items-center gap-1.5">
+                    <Bot size={8} className="text-yellow-400/70 shrink-0" />
+                    <span className="text-[7.5px] font-medium text-zinc-300">{name}</span>
+                  </div>
+                  <div className="w-1.5 h-1.5 rounded-full bg-green-400 shrink-0" />
+                </div>
+              ))}
+            </div>
+            <div className="flex items-center gap-1 mt-1">
+              <span className="text-[6px] font-bold uppercase tracking-widest text-yellow-400">Click to Refine Facts</span>
+              <ArrowUpRight size={8} className="text-yellow-400" />
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}
+
+// ─── Library page mock UI ─────────────────────────────────────────────────────
+// Faithfully renders: page header, "Currently in Use" cards, "All Documents" archive rows.
+// Step-specific state:
+//   step 0: card 0 highlighted
+//   step 1: + Add Info button glows, new row appears in archive
+//   step 2: card 0 hover overlay reveals connected assistants
+//   step 3: first archive row highlighted, chevron visible
+
+function LibraryMockUI({ step }: { step: number }) {
+  const showNewRow    = step >= 1;
+  const showOverlay   = step === 2;
+  const highlightRow0 = step === 3;
+
+  return (
+    <div className="flex flex-col h-full select-none overflow-hidden">
+
+      {/* ── Page header (mirrors: "Knowledge" title + search + "+ Add Info" button) ── */}
+      <div
+        className="shrink-0 bg-zinc-900/80 border-b border-zinc-800 px-3 flex items-center justify-between"
+        style={{ height: 36 }}
+      >
+        <span className="text-[9px] font-bold text-white tracking-widest uppercase">Knowledge</span>
+        <div className="flex items-center gap-1.5">
+          {/* Search shape */}
+          <div className="h-5 w-[72px] rounded bg-zinc-700/60 flex items-center px-2 gap-1.5">
+            <div className="w-1.5 h-1.5 rounded-full bg-zinc-500 shrink-0" />
+            <div className="h-1 flex-1 bg-zinc-600/70 rounded-full" />
+          </div>
+          {/* + Add Info button — glows on step 1 */}
+          <div
+            className={`h-5 px-2 rounded-[3px] flex items-center gap-1 transition-all duration-300 ${
+              step === 1
+                ? 'bg-white shadow-[0_0_12px_5px_rgba(255,255,255,0.22)]'
+                : 'bg-zinc-200/90'
+            }`}
+          >
+            <span className="text-[7.5px] font-bold text-zinc-900">+ Add Info</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── "Currently in Use" section (mirrors: h2 + ACTIVE badge + card grid) ── */}
+      <div className="shrink-0 px-3 flex items-center gap-2" style={{ height: 28 }}>
+        <span className="text-[7px] font-bold uppercase tracking-[0.25em] text-zinc-300">Currently in Use</span>
+        <div className="h-px flex-1 bg-zinc-700/40" />
+        <div className="px-1.5 py-0.5 rounded bg-yellow-400/10 border border-yellow-400/20">
+          <span className="text-[6px] font-mono text-yellow-400/80">2 ACTIVE</span>
+        </div>
+      </div>
+
+      {/* Knowledge cards */}
+      <div className="px-3 pb-2 grid grid-cols-2 gap-2 shrink-0">
+        {/* Card 0 — Pricing Guide */}
+        <MockKnowledgeCard
+          date="15 Jan 2025"
+          filename="Pricing Guide 2025"
+          snippet="Our enterprise pricing includes three tiers. Standard at $99/month with basic features, Pro at $299..."
+          wordCount="420 words"
+          linkCount={2}
+          highlighted={step === 0 || step === 2}
+          showOverlay={showOverlay}
+        />
+        {/* Card 1 — FAQ Sheet */}
+        <MockKnowledgeCard
+          date="3 Feb 2025"
+          filename="FAQ Sheet"
+          snippet="Q: How do I set up a campaign? A: Navigate to Campaigns and tap New. Q: Can I change voice mid-call..."
+          wordCount="280 words"
+          linkCount={1}
+          highlighted={false}
+          showOverlay={false}
+        />
+      </div>
+
+      {/* ── "All Documents" archive section ── */}
+      {/* Section header + filter pills */}
+      <div className="shrink-0 mx-3 flex items-center justify-between" style={{ height: 28 }}>
+        <span className="text-[7px] font-bold uppercase tracking-[0.25em] text-zinc-500">All Documents</span>
+        <div className="flex items-center gap-1">
+          {['All', 'Last 7d', 'Last 30d'].map((f, i) => (
+            <div
+              key={f}
+              className={`px-1.5 py-0.5 rounded text-[6px] font-bold uppercase tracking-widest ${
+                i === 0 ? 'bg-zinc-700 text-zinc-200' : 'text-zinc-600'
+              }`}
+            >
+              {f}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Archive rows — mirror real ArchiveRow: file icon + name + date + chevron */}
+      <div className="mx-3 rounded-md border border-zinc-700/40 overflow-hidden flex-1">
+        {[
+          { name: 'Objection Handbook.txt', date: '28 Jan' },
+          { name: 'Script v4.txt',          date: '12 Jan' },
+          { name: 'Competitors.txt',        date: '5 Jan'  },
+        ].map((row, i) => (
+          <div
+            key={row.name}
+            className={`flex items-center gap-2 px-2.5 transition-all duration-200 ${
+              i < 2 ? 'border-b border-zinc-700/30' : ''
+            } ${
+              highlightRow0 && i === 0
+                ? 'bg-yellow-400/10'
+                : 'bg-transparent'
+            }`}
+            style={{ height: 34 }}
+          >
+            <div className="w-5 h-5 rounded bg-zinc-700 flex items-center justify-center shrink-0">
+              <FileText size={9} className="text-zinc-400" />
+            </div>
+            <div className="flex-1 min-w-0">
+              <div className="text-[7.5px] font-medium text-zinc-300 truncate">{row.name}</div>
+              <div className="text-[6px] text-zinc-600">{row.date}</div>
+            </div>
+            <ChevronRight
+              size={10}
+              className={`shrink-0 transition-all duration-200 ${
+                highlightRow0 && i === 0 ? 'text-yellow-400 opacity-100' : 'text-zinc-600 opacity-40'
+              }`}
+            />
+          </div>
+        ))}
+
+        {/* New document row — animates in on step 1 */}
+        <AnimatePresence>
+          {showNewRow && (
+            <motion.div
+              key="new-row"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 34, opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ duration: 0.35, ease: 'easeOut', delay: 0.85 }}
+              className="flex items-center gap-2 px-2.5 border-t border-zinc-700/30 bg-yellow-400/5 overflow-hidden"
+            >
+              <div className="w-5 h-5 rounded bg-yellow-400/20 flex items-center justify-center shrink-0">
+                <FileText size={9} className="text-yellow-400/70" />
+              </div>
+              <div className="flex-1 min-w-0">
+                <div className="text-[7.5px] font-medium text-yellow-400/80 truncate">New Document.txt</div>
+                <div className="text-[6px] text-yellow-400/40">Just now</div>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+
+      {/* Bottom breathing room */}
+      <div className="shrink-0" style={{ height: 8 }} />
+    </div>
+  );
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+interface LibraryOnboardingProps {
+  isOpen: boolean;
+  onComplete: () => void;
+}
+
+export function LibraryOnboarding({ isOpen, onComplete }: LibraryOnboardingProps) {
+  const [step, setStep] = useState(0);
+  const [showRipple, setShowRipple] = useState(false);
+
+  const cursorX = useMotionValue(CURSOR_POS[0].x);
+  const cursorY = useMotionValue(CURSOR_POS[0].y);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const pos = CURSOR_POS[step];
+    animate(cursorX, pos.x, { duration: 0.75, ease: 'easeInOut' });
+    animate(cursorY, pos.y, { duration: 0.75, ease: 'easeInOut' });
+
+    // Click ripple on step 1 (cursor arrives at + Add Info)
+    if (step === 1) {
+      const t = setTimeout(() => {
+        setShowRipple(true);
+        setTimeout(() => setShowRipple(false), 600);
+      }, 820);
+      return () => clearTimeout(t);
+    }
+  }, [step, isOpen]);
+
+  useEffect(() => {
+    if (isOpen) setStep(0);
+  }, [isOpen]);
+
+  const handleCta = () => {
+    if (step < STEPS.length - 1) {
+      setStep(s => s + 1);
+    } else {
+      onComplete();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+      <motion.div
+        initial={{ opacity: 0, scale: 0.95, y: 10 }}
+        animate={{ opacity: 1, scale: 1, y: 0 }}
+        exit={{ opacity: 0, scale: 0.95, y: 10 }}
+        transition={{ duration: 0.25, ease: 'easeOut' }}
+        className="w-full max-w-4xl h-[560px] flex rounded-xl overflow-hidden shadow-2xl border border-white/[0.08]"
+      >
+
+        {/* ── LEFT PANEL ─────────────────────────────────────────────────── */}
+        <div
+          className="relative w-1/2 bg-zinc-950 flex flex-col overflow-hidden"
+          style={{ colorScheme: 'dark' }}
+        >
+          {/* Browser chrome */}
+          <div
+            className="shrink-0 flex items-center gap-1.5 px-3 bg-zinc-900/90 border-b border-zinc-800"
+            style={{ height: 36 }}
+          >
+            <div className="w-2.5 h-2.5 rounded-full bg-red-500/70" />
+            <div className="w-2.5 h-2.5 rounded-full bg-yellow-500/70" />
+            <div className="w-2.5 h-2.5 rounded-full bg-green-500/70" />
+            <div className="ml-2 flex-1 h-4 rounded bg-zinc-800/80 flex items-center px-2">
+              <span className="text-[7.5px] text-zinc-500">app.monade.ai/knowledge-base</span>
+            </div>
+          </div>
+
+          {/* Mock page — does NOT re-mount between steps */}
+          <div className="flex-1 overflow-hidden">
+            <LibraryMockUI step={step} />
+          </div>
+
+          {/* Animated cursor */}
+          <motion.div
+            className="absolute top-0 left-0 pointer-events-none z-20"
+            style={{ x: cursorX, y: cursorY }}
+          >
+            <svg width="16" height="20" viewBox="0 0 16 20" fill="none">
+              <path
+                d="M1 1L1 15.5L4 12L6.5 17.5L8.5 16.5L6 11H10L1 1Z"
+                fill="white"
+                stroke="#111"
+                strokeWidth="1.2"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <AnimatePresence>
+              {showRipple && (
+                <motion.div
+                  key="ripple"
+                  className="absolute top-0 left-0 rounded-full bg-white/25"
+                  style={{ width: 22, height: 22, x: -3, y: -3 }}
+                  initial={{ scale: 0.4, opacity: 0.8 }}
+                  animate={{ scale: 2.2, opacity: 0 }}
+                  exit={{ opacity: 0 }}
+                  transition={{ duration: 0.48, ease: 'easeOut' }}
+                />
+              )}
+            </AnimatePresence>
+          </motion.div>
+        </div>
+
+        {/* ── RIGHT PANEL ─────────────────────────────────────────────────── */}
+        <div className="relative w-1/2 bg-background flex flex-col p-8 border-l border-border/20">
+          <button
+            onClick={onComplete}
+            className="absolute top-5 right-5 p-1.5 text-muted-foreground hover:text-foreground transition-colors"
+            aria-label="Skip onboarding"
+          >
+            <X size={16} />
+          </button>
+
+          <span className="text-[10px] font-bold text-primary uppercase tracking-[0.3em] mb-6">
+            {STEPS[step].num} / 04
+          </span>
+
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={step}
+              initial={{ opacity: 0, x: 18 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -18 }}
+              transition={{ duration: 0.22, ease: 'easeInOut' }}
+              className="flex-1 flex flex-col gap-5"
+            >
+              <h2 className="text-2xl font-medium tracking-tight text-foreground leading-tight">
+                {STEPS[step].title}
+              </h2>
+              <p className="text-sm text-muted-foreground leading-relaxed">
+                {STEPS[step].desc}
+              </p>
+              <ul className="space-y-2 mt-1">
+                {STEPS[step].bullets.map((b, i) => (
+                  <li key={i} className="flex items-start gap-2 text-sm text-foreground/80">
+                    <span className="text-primary mt-0.5 shrink-0">•</span>
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
+            </motion.div>
+          </AnimatePresence>
+
+          <div className="flex items-center justify-between mt-auto pt-6 border-t border-border/20">
+            <button
+              onClick={() => setStep(s => Math.max(0, s - 1))}
+              className={`text-xs font-medium transition-all ${
+                step === 0
+                  ? 'opacity-0 pointer-events-none'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              ← Back
+            </button>
+
+            <div className="flex items-center gap-1.5">
+              {STEPS.map((_, i) => (
+                <div
+                  key={i}
+                  className={`rounded-full transition-all duration-300 ${
+                    i === step ? 'w-4 h-1.5 bg-primary' : 'w-1.5 h-1.5 bg-border'
+                  }`}
+                />
+              ))}
+            </div>
+
+            <button
+              onClick={handleCta}
+              className="px-4 py-2 bg-foreground text-background text-xs font-bold uppercase tracking-[0.15em] rounded-[4px] hover:bg-foreground/90 transition-all"
+            >
+              {STEPS[step].cta}
+            </button>
+          </div>
+        </div>
+      </motion.div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **All 4 steps are navigable** — previous version had steps 3 and 4 unreachable (steps 2 and 3 closed the dialog via `onHighlight` before the user could advance)
- **Faithful mock UIs** — left panel now accurately mirrors the real component layouts:
  - Assistants: avatar circle + name + READY badge + Primary Role label + italic description + Model/Voice 2-col grid + Operating History + circle arrow button
  - Library: "Added DATE" label (primary color) + Links badge + filename + monospace snippet + Volume/Market stats; plus archive rows matching the real `ArchiveRow` structure
- **Cursor lands on actual elements** — positions calculated from explicit mock layout dimensions (browser bar 36px, header 36px, tabs 24px, grid padding 12px, card heights) so cursor arrives at the right spot
- **Distinct per-step animations** — each step has a unique visual state: card hover, button glow + draft card, studio panel slide, arrow button highlight (Assistants); card hover, button glow + new archive row, hover overlay reveal, archive row highlight (Library)

## Test plan

- [ ] Delete `monade_assistants_onboarding_v1` from DevTools → navigate to `/assistants` → all 4 steps reachable via Next/Back
- [ ] Step 2: cursor moves to + Add button, button glows, draft card fades in at ~850ms
- [ ] Step 3: cursor returns to card 0, studio panel slides in from right
- [ ] Step 4: cursor lands on arrow button, button turns yellow
- [ ] Delete `monade_library_onboarding_v1` → navigate to `/knowledge-base` → all 4 steps work
- [ ] Step 2: cursor moves to + Add Info, button glows, new archive row appears
- [ ] Step 3: cursor on card 0, "Connected Assistants" overlay slides up from card bottom
- [ ] Step 4: cursor on first archive row, row highlights and chevron becomes visible
- [ ] Refresh after completing either onboarding — dialog does not reappear
- [ ] Skip button closes and marks done
- [ ] Left panel always dark; right panel respects system theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)